### PR TITLE
Surround keytool path with double quotes (closes #3)

### DIFF
--- a/libraries/provider_java_certificate.rb
+++ b/libraries/provider_java_certificate.rb
@@ -117,8 +117,6 @@ class Chef::Provider::JavaCertificate < Chef::Provider::LWRPBase
       truststore = "#{java_home}/jre/lib/security/cacerts" if truststore.nil?
       truststore_passwd = "changeit" if truststore_passwd.nil?
           
-      keytool = "#{java_home}/bin/keytool"
-
       has_key = !`#{keytool} -list -keystore #{truststore} -storepass #{truststore_passwd} -v | grep "#{certalias}"`[/Alias name: #{certalias}/].nil?
       Chef::Application.fatal!("Error querying keystore for existing certificate: #{$?}", $?.to_s[/exit (\d+)/, 1].to_i) unless $?.success?
       


### PR DESCRIPTION
This PR surrounds the keytool command path with doubles quotes when running on Windows platform.

Two helper methods are added at the end of the provider to build the java_home and keytool paths.

The PR also includes the following changes:
- remove `directory "#{Chef::Config[:file_cache_path]}"}}}` resource declarations, as they are not necessary (I assume this directory always exists) and they generate warnings (resource cloning)
- replace calls to `node['java']['java_home']` by the `java_home` variable  
