### PR TITLE
Fix encoding validity on French installation.

### DIFF
--- a/libraries/provider_java_certificate.rb
+++ b/libraries/provider_java_certificate.rb
@@ -79,6 +79,10 @@ class Chef::Provider::JavaCertificate < Chef::Provider::LWRPBase
           Chef::Log.debug("Executing: #{keytool} -list -keystore #{truststore} -storepass #{truststore_passwd} -v | grep \"#{certalias}\"\n#{result}")
           Chef::Application.fatal!("Error querying keystore for existing certificate: #{$?}", $?.to_s[/exit (\d+)/, 1].to_i) unless $?.success?
           
+          if ! result.valid_encoding?
+            result = result.encode("UTF-16be", :invalid=>:replace, :replace=>"?").encode('UTF-8')
+          end
+          
           has_key = !result[/Alias name: #{certalias}/].nil?
           
           if has_key


### PR DESCRIPTION
The keytool command outputs according to encoding set at OS level.
It raises an error if this output includes character not encoded in UTF-8.
